### PR TITLE
Remove site.title from default page for small screens

### DIFF
--- a/_includes/default.html
+++ b/_includes/default.html
@@ -61,7 +61,6 @@
 			{% endif %}
 			<a class="navbar-brand" href="{{ site.BASE_PATH }}/">
 				<h3> Home </h3>
-				{{ site.title }}
 			</a>
 		</div>
 


### PR DESCRIPTION
**Description**
- For small screens, there was link showing base url for the root of site

#### Pre-Submission Checklist :ballot_box_with_check:
- [ ] Feature
- [ ] Bug
- [x] Tested
- [ ] Post